### PR TITLE
Fix index panic if no argument supplied

### DIFF
--- a/ineffassign.go
+++ b/ineffassign.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	if len(os.Args) < 1 {
+	if len(os.Args) != 2 {
 		fmt.Println("missing argument: filepath")
 		return
 	}


### PR DESCRIPTION
Check that there are exactly two values in argv, the program name and the package.