### PR TITLE
Ignore generated files

### DIFF
--- a/ineffassign.go
+++ b/ineffassign.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"dmitri.shuralyov.com/go/generated"
 )
 
 const invalidArgumentExitCode = 3
@@ -56,6 +58,9 @@ func walkPath(root string) bool {
 			return nil
 		}
 		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if isGenerated, _ := generated.ParseFile(path); isGenerated {
 			return nil
 		}
 		fset, _, ineff := checkPath(path)


### PR DESCRIPTION
Closes  #39, as per that thread I used [Dmitri Shuralyov's "generated" package](https://dmitri.shuralyov.com/go/generated) to detect if a `.go` file is generated. Currently, these files will always be generated. We could add a program flag that can be used to disable/enable ignoring generated file (I'm personally in favor of ignoring generated files by default and adding an option to not do so).

I did not create a unit test for this feature as I'm not sure how to adopt the current testing strategy for the new feature. Existing tests call [`checkPath()`](https://github.com/gordonklaus/ineffassign/blob/e36bfde3bb78d229b1564c1d34b292ba39bbb542/ineffassign.go#L71-L88) directly, but I added the functionality for this feature to [`walkPath()`](https://github.com/gordonklaus/ineffassign/blob/e36bfde3bb78d229b1564c1d34b292ba39bbb542/ineffassign.go#L43-L69).