### PR TITLE
Add support for Go standard use of ./...

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This tool misses some cases because it does not consider any type information in
 
 For basic usage, run the following command from the root of your project:
 
-    ineffassign ./*
+    ineffassign ./...
 
 Which will analyze all packages beneath the current directory.
 

--- a/ineffassign.go
+++ b/ineffassign.go
@@ -6,6 +6,7 @@ import (
 	"go/ast"
 	"go/token"
 	"sort"
+	"strings"
 
 	"golang.org/x/tools/go/analysis"
 	"golang.org/x/tools/go/analysis/singlechecker"
@@ -27,8 +28,16 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func checkPath(pass *analysis.Pass) (interface{}, error) {
-	files := pass.Files
-	for _, file := range files {
+files:
+	for _, file := range pass.Files {
+		for _, cg := range file.Comments {
+			for _, c := range cg.List {
+				if strings.HasPrefix(c.Text, "// Code generated ") && strings.HasSuffix(c.Text, " DO NOT EDIT.") {
+					continue files
+				}
+			}
+		}
+
 		bld := &builder{vars: map[*ast.Object]*variable{}}
 		bld.walk(file)
 

--- a/ineffassign.go
+++ b/ineffassign.go
@@ -16,7 +16,7 @@ import (
 
 const invalidArgumentExitCode = 3
 
-var dontRecurseFlag = flag.Bool("n", false, "don't recursively check paths")
+var dontRecurseFlag = flag.Bool("n", false, "[DEPRECATED] don't recursively check paths")
 
 func main() {
 	flag.Parse()

--- a/ineffassign.go
+++ b/ineffassign.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"go/ast"
 	"go/token"
@@ -12,6 +13,10 @@ import (
 
 func main() {
 	singlechecker.Main(Analyzer)
+}
+
+func init() {
+	flag.Bool("n", false, "don't recursively check paths (deprecated)")
 }
 
 // Analyzer is the ineffassign analysis.Analyzer instance.
@@ -35,7 +40,7 @@ func checkPath(pass *analysis.Pass) (interface{}, error) {
 
 		for _, id := range chk.ineff {
 			pass.Report(analysis.Diagnostic{
-				Pos: id.Pos(),
+				Pos:     id.Pos(),
 				Message: fmt.Sprintf("ineffectual assignment to %s", id.Name),
 			})
 		}

--- a/ineffassign.go
+++ b/ineffassign.go
@@ -28,14 +28,9 @@ var Analyzer = &analysis.Analyzer{
 }
 
 func checkPath(pass *analysis.Pass) (interface{}, error) {
-files:
 	for _, file := range pass.Files {
-		for _, cg := range file.Comments {
-			for _, c := range cg.List {
-				if strings.HasPrefix(c.Text, "// Code generated ") && strings.HasSuffix(c.Text, " DO NOT EDIT.") {
-					continue files
-				}
-			}
+		if isGenerated(file) {
+			continue
 		}
 
 		bld := &builder{vars: map[*ast.Object]*variable{}}
@@ -56,6 +51,18 @@ files:
 	}
 
 	return nil, nil
+}
+
+func isGenerated(file *ast.File) bool {
+	for _, cg := range file.Comments {
+		for _, c := range cg.List {
+			if strings.HasPrefix(c.Text, "// Code generated ") && strings.HasSuffix(c.Text, " DO NOT EDIT.") {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 type builder struct {

--- a/ineffassign_test.go
+++ b/ineffassign_test.go
@@ -7,13 +7,5 @@ import (
 )
 
 func Test(t *testing.T) {
-	results := analysistest.Run(t, analysistest.TestData(), Analyzer)
-	if len(results) != 1 {
-		t.Fatalf("Unexpected number of results (%d)", len(results))
-	}
-
-	result := results[0]
-	if result.Err != nil {
-		t.Fatalf("Unexpected error %s", result.Err)
-	}
+	analysistest.Run(t, analysistest.TestData(), Analyzer)
 }

--- a/ineffassign_test.go
+++ b/ineffassign_test.go
@@ -1,25 +1,19 @@
 package main
 
 import (
-	"strings"
 	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
 )
 
 func Test(t *testing.T) {
-	fset, comments, ineff := checkPath("testdata/testdata.go")
-	expected := map[int]string{}
-	for _, c := range comments {
-		expected[fset.Position(c.Pos()).Line] = strings.TrimSpace(c.Text())
+	results := analysistest.Run(t, analysistest.TestData(), Analyzer)
+	if len(results) != 1 {
+		t.Fatalf("Unexpected number of results (%d)", len(results))
 	}
 
-	for _, id := range ineff {
-		line := fset.Position(id.Pos()).Line
-		if name, ok := expected[line]; !ok || name != id.Name {
-			t.Error("unexpected:", line, id.Name)
-		}
-		delete(expected, line)
-	}
-	for line, name := range expected {
-		t.Error("expected:", line, name)
+	result := results[0]
+	if result.Err != nil {
+		t.Fatalf("Unexpected error %s", result.Err)
 	}
 }

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -55,7 +55,7 @@ func _() {
 }
 
 func _() {
-	x := T(0)
+	x := int(0)
 	x = 0
 	_ = x
 }
@@ -205,21 +205,22 @@ func _() {
 }
 
 func _() {
-	x := 0
+	type T struct{ f int }
+	x := T{}
 	_ = x.f
-	x = 0
+	x = T{}
 }
 
 func _() {
-	x := 0
+	x := []int{}
 	_ = &x[0]
-	x = 0
+	x = []int{}
 }
 
 func _() {
-	x := 0
+	x := []int{}
 	_ = x[:]
-	x = 0
+	x = []int{}
 }
 
 func _() {
@@ -283,75 +284,75 @@ func _() (x int) {
 	return x
 }
 
-func _() (x int) {
+func _(anyFunctionMightPanic func()) (x int) {
 	x = 1
 	anyFunctionMightPanic()
 	return 2
 }
 
-func _() (x int) {
+func _(a []int) (x int) {
 	x = 1
-	_ = a[i]
+	_ = a[1]
 	return 2
 }
 
-func _() (x int) {
+func _(a []int) (x int) {
 	x = 1
-	_ = a[i:j]
+	_ = a[2:4]
 	return 2
 }
 
-func _() (x int) {
+func _(a, b interface{}) (x int) {
 	x = 1
 	_ = a == b
 	return 2
 }
 
-func _() (x int) {
+func _(a, b int) (x int) {
 	x = 1
 	_ = a / b
 	return 2
 }
 
-func _() (x int) {
+func _(a, b int) (x int) {
 	x = 1
-	a /= b
+	_ = a / b
 	return 2
 }
 
-func _() (x int) {
+func _(a, b int) (x int) {
 	x = 1
 	_ = a % b
 	return 2
 }
 
-func _() (x int) {
+func _(a, b int) (x int) {
 	x = 1
-	a %= b
+	_ = a % b
 	return 2
 }
 
-func _() (x int) {
+func _(a *struct{ b int }) (x int) {
 	x = 1
 	_ = a.b
 	return 2
 }
 
-func _() (x int) {
+func _(a *int) (x int) {
 	x = 1
 	_ = *a
 	return 2
 }
 
-func _() (x int) {
+func _(a interface{}) (x int) {
 	x = 1
 	_ = a.(int)
 	return 2
 }
 
-func _() (x int) {
+func _(a chan int) (x int) {
 	x = 1
-	a <- b
+	a <- 1
 	return 2
 }
 
@@ -395,6 +396,8 @@ func _() {
 		fallthrough
 	case b:
 	}
+	x = 0
+	_ = x
 }
 
 func _() {

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -19,12 +19,12 @@ func _() {
 func _() {
 	var x int
 	_ = x
-	x = 0 //x
+	x = 0 // want "ineffectual assignment to x"
 }
 
 func _() {
 	var x int
-	x = 0 //x
+	x = 0 // want "ineffectual assignment to x"
 	x = 0
 	_ = x
 }
@@ -42,14 +42,14 @@ func _() {
 }
 
 func _() {
-	x := true //x
+	x := true // want "ineffectual assignment to x"
 	x = false
 	_ = x
 }
 
 func _() {
 	false := "not the real false"
-	x := false //x
+	x := false // want "ineffectual assignment to x"
 	x = "also not false"
 	_ = x
 }
@@ -67,13 +67,13 @@ func _() {
 }
 
 func _() {
-	x := "abc" //x
+	x := "abc" // want "ineffectual assignment to x"
 	x = "def"
 	_ = x
 }
 
 func _() {
-	x := 1 //x
+	x := 1 // want "ineffectual assignment to x"
 	x = 0
 	_ = x
 }
@@ -105,18 +105,18 @@ func _() {
 }
 
 func _() {
-	x := 1 //x
+	x := 1 // want "ineffectual assignment to x"
 	if b {
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 	}
 	x = 0
 	_ = x
 }
 
 func _() {
-	x := 1 //x
+	x := 1 // want "ineffectual assignment to x"
 	for b {
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 	}
 	x = 0
 	_ = x
@@ -134,13 +134,13 @@ func _() {
 }
 
 func _() {
-	x := 1 //x
+	x := 1 // want "ineffectual assignment to x"
 	if b {
-		x = 0 //x
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
+		x = 0 // want "ineffectual assignment to x"
 	}
 	if b {
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 	}
 	x = 0
 	_ = x
@@ -149,7 +149,7 @@ func _() {
 func _() {
 	x := 0
 	if b {
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 		x = 0
 	}
 	if b {
@@ -170,7 +170,7 @@ func _() {
 	x := 0
 	for {
 		_ = x
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 		x = 0
 	}
 }
@@ -178,7 +178,7 @@ func _() {
 func _() {
 	x := 0
 	for {
-		x += 0 //x
+		x += 0 // want "ineffectual assignment to x"
 		x = 0
 	}
 }
@@ -186,7 +186,7 @@ func _() {
 func _() {
 	x := 0
 	for {
-		x++ //x
+		x++ // want "ineffectual assignment to x"
 		x = 0
 	}
 }
@@ -269,13 +269,13 @@ func _() (x int) {
 }
 
 func _() (x int) {
-	x = 0 //x
+	x = 0 // want "ineffectual assignment to x"
 	x = 0
 	return
 }
 
 func _() (x int) {
-	x = 0 //x
+	x = 0 // want "ineffectual assignment to x"
 	return 0
 }
 
@@ -392,7 +392,7 @@ func _() {
 	var x int
 	switch b {
 	default:
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 		fallthrough
 	case b:
 	}
@@ -439,16 +439,16 @@ func _() {
 	var ch chan int
 	select {
 	case ch <- 0:
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 	case <-ch:
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 	default:
 		_ = x
 	}
 }
 
 func _() {
-	x := 1 //x
+	x := 1 // want "ineffectual assignment to x"
 	var ch chan int
 	select {
 	case ch <- 0:
@@ -495,7 +495,7 @@ func _() {
 func _() {
 	var x int
 	if b {
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 	}
 	if x = 0; b {
 
@@ -549,7 +549,7 @@ func _() {
 func _() {
 	x := 0
 	for x < 0 {
-		x = 0 //x
+		x = 0 // want "ineffectual assignment to x"
 		if b {
 			break
 		}
@@ -587,7 +587,7 @@ func _() {
 	var x int
 	for {
 		if b {
-			x = 0 //x
+			x = 0 // want "ineffectual assignment to x"
 			break
 		}
 		_ = x
@@ -623,7 +623,7 @@ func _() {
 func _() {
 	x := 0
 	if b {
-		x = 1 // x
+		x = 1 // want "ineffectual assignment to x"
 		return
 	}
 	_ = x


### PR DESCRIPTION
This adds support for Go standard use of `./...` to recursively analyze a directory.

Note that this breaks current usage in two ways:

- Current invocation paths that are recursive will no longer be recursive. Currently all invocations are recursive unless the `-n` flag is used. After this change such invocations will be non-recursive unless the "/..." suffix is added.
- The `-n` flag is deprecated as it is no longer meaningful with `./...` support. I deprecated it instead of removing it because if the flag is used when not registered the program exits with an error before doing anything.