### PR TITLE
Update analyzer doc to match with golangci-lint

### DIFF
--- a/pkg/ineffassign/ineffassign.go
+++ b/pkg/ineffassign/ineffassign.go
@@ -13,7 +13,7 @@ import (
 // Analyzer is the ineffassign analysis.Analyzer instance.
 var Analyzer = &analysis.Analyzer{
 	Name: "ineffassign",
-	Doc:  "detect ineffectual assignments in Go code",
+	Doc:  "detects when assignments to existing variables are not used",
 	Run:  checkPath,
 }
 


### PR DESCRIPTION
This PR change analyzer doc to be the same as in the [golangci-lint](https://github.com/alexandear/golangci-lint/blob/82b407ee2e735cf868004e9919fc732aa95508b7/pkg/golinters/ineffassign.go#L15C3-L15C3).