### PR TITLE
docs: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This tool misses some cases because it does not consider any type information in
 
 ## Install
 
-    go get -u github.com/gordonklaus/ineffassign
+    go install github.com/gordonklaus/ineffassign@latest
 
 ## Usage
 


### PR DESCRIPTION
`go get` currently modifies the `go.mod` file and that's probably not what you want installing a linter. Use `go install` instead.

https://go.dev/ref/mod
