### PR TITLE
Adds an end position for identifier when emitting diagnostics

### DIFF
--- a/pkg/ineffassign/ineffassign.go
+++ b/pkg/ineffassign/ineffassign.go
@@ -35,6 +35,7 @@ func checkPath(pass *analysis.Pass) (interface{}, error) {
 		for _, id := range chk.ineff {
 			pass.Report(analysis.Diagnostic{
 				Pos:     id.Pos(),
+				End:     id.End(),
 				Message: fmt.Sprintf("ineffectual assignment to %s", id.Name),
 			})
 		}


### PR DESCRIPTION
Currently, the diagnostics emitted by the analyzer only specify a starting position.  While this is all that's required in order to get the analyzer to function properly, it means that when the diagnostics are displayed in an IDE (when the analyzer is running as part of an LSP server, for example), only the first character of the offending identifier is highlighted:

<img width="348" alt="Screenshot 2025-06-27 at 09 23 56" src="https://github.com/user-attachments/assets/a8da487d-c39d-4d90-ab5b-dee493431a1f" />

If we _also_ specify the optional ending position of the identifer, the emitted diagnostic is much nicer and more visible to the LSP user:

<img width="571" alt="Screenshot 2025-06-27 at 09 24 58" src="https://github.com/user-attachments/assets/8a55f814-ec1b-40e6-924e-49a6247d6b6b" />

The existing tests all still pass with this addition, since the tests are built with the `golang.org/x/tools/go/analysis/analysistest` package and the corresponding `// want` comments, with only require that the analyzer emit the correct beginning line number. ([example](https://github.com/gordonklaus/ineffassign/blob/b5bbf40bc28923f7ce598c8b74958b2a36a063da/pkg/ineffassign/testdata/testdata.go#L27))

Let me know what you think about this change. I'm happy to rework/modify the PR in any way you see fit.  Thanks for the incredibly helpful linter/analyzer!