### PR TITLE
Use the IsGenerated function from the go/ast package

### DIFF
--- a/pkg/ineffassign/ineffassign.go
+++ b/pkg/ineffassign/ineffassign.go
@@ -19,7 +19,7 @@ var Analyzer = &analysis.Analyzer{
 
 func checkPath(pass *analysis.Pass) (interface{}, error) {
 	for _, file := range pass.Files {
-		if isGenerated(file) {
+		if ast.IsGenerated(file) {
 			continue
 		}
 
@@ -42,18 +42,6 @@ func checkPath(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	return nil, nil
-}
-
-func isGenerated(file *ast.File) bool {
-	for _, cg := range file.Comments {
-		for _, c := range cg.List {
-			if strings.HasPrefix(c.Text, "// Code generated ") && strings.HasSuffix(c.Text, " DO NOT EDIT.") {
-				return true
-			}
-		}
-	}
-
-	return false
 }
 
 type builder struct {


### PR DESCRIPTION
Go 1.21 introduced a new `IsGenerated(*ast.File) bool` func to the `go/ast` package:

- https://go.dev/doc/go1.21#goastpkggoast
- https://github.com/golang/go/issues/28089

This function uses the canonical check for generated code, as described in https://pkg.go.dev/cmd/go#hdr-Generate_Go_files_by_processing_source.

As is Go tradition, the standard library packages should be used whenever possible. 😄 

There should be no net change to the functionality of `ineffassign` as a result of this change, just an increase in standardization.