### PR TITLE
add flag to optionally check for escaping errors

### DIFF
--- a/ineffassign.go
+++ b/ineffassign.go
@@ -35,7 +35,6 @@ func main() {
 		}
 		fmt.Fprintln(os.Stderr, "\nFlags:")
 		flag.PrintDefaults()
-		ineffassign.Analyzer.Flags.PrintDefaults()
 	}
 	ineffassign.Analyzer.Flags.VisitAll(func(f *flag.Flag) {
 		flag.Var(f.Value, f.Name, f.Usage)


### PR DESCRIPTION
resolves #89

I'm just checking if the variable is named `err`. In theory it looks like type information is available under `id.Obj.Decl` but it doesn't look like that's used anywhere else and I noticed some comments around type information not being available, so I'm not sure if that doesn't work on older versions of go or something.